### PR TITLE
Add QoSProfile for ROS1

### DIFF
--- a/autopsy/node.py
+++ b/autopsy/node.py
@@ -55,9 +55,11 @@ try:
     import rospy
 
     from .ros1_node import Node as NodeI
+    from .ros1_qos import *
 except:
     try:
         from rclpy.node import Node as NodeI
+        from rclpy.qos import *
     except:
         print ("No ROS package detected.")
 
@@ -89,7 +91,7 @@ class Node(NodeI):
         Reference:
         http://docs.ros.org/en/kinetic/api/rospy/html/rospy.topics.Publisher-class.html
         """
-        return super(Node, self).create_publisher(msg_type = data_class, topic = name, qos_profile = queue_size)
+        return super(Node, self).create_publisher(msg_type = data_class, topic = name, qos_profile = QoSProfile(depth = queue_size, durability = DurabilityPolicy.TRANSIENT_LOCAL if latch else DurabilityPolicy.VOLATILE))
 
 
     def Subscriber(self, name, data_class, callback=None, callback_args=None, queue_size=None, buff_size=65536, tcp_nodelay=False):
@@ -104,7 +106,7 @@ class Node(NodeI):
         Reference:
         http://docs.ros.org/en/kinetic/api/rospy/html/rospy.topics.Subscriber-class.html
         """
-        return super(Node, self).create_subscription(msg_type = data_class, topic = name, callback = callback, qos_profile = queue_size)
+        return super(Node, self).create_subscription(msg_type = data_class, topic = name, callback = callback, qos_profile = QoSProfile(depth = queue_size))
 
 
     def Rate(self, hz, reset=False):

--- a/autopsy/ros1_node.py
+++ b/autopsy/ros1_node.py
@@ -8,6 +8,8 @@
 
 import rospy
 
+from .ros1_qos import DurabilityPolicy
+
 
 ######################
 # Node class
@@ -45,7 +47,7 @@ class Node(object):
         Reference:
         https://docs.ros2.org/latest/api/rclpy/api/node.html#rclpy.node.Node.create_publisher
         """
-        return rospy.Publisher(name = topic, data_class = msg_type, queue_size = qos_profile)
+        return rospy.Publisher(name = topic, data_class = msg_type, latch = qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL, queue_size = qos_profile.depth)
 
 
     def create_subscription(self, msg_type, topic, callback, qos_profile, **kwargs):
@@ -61,7 +63,7 @@ class Node(object):
         Reference:
         https://docs.ros2.org/latest/api/rclpy/api/node.html#rclpy.node.Node.create_subscription
         """
-        return rospy.Subscriber(name = topic, data_class = msg_type, callback = callback, queue_size = qos_profile)
+        return rospy.Subscriber(name = topic, data_class = msg_type, callback = callback, queue_size = qos_profile.depth)
 
 
     def create_rate(self, frequency, **kwargs):

--- a/autopsy/ros1_qos.py
+++ b/autopsy/ros1_qos.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# ros1_qos.py
+"""ROS2 QoSProfile compatible implementation for ROS1.
+"""
+######################
+# Imports & Globals
+######################
+
+from enum import Enum
+
+
+######################
+# QoSDurabilityPolicy
+######################
+
+class DurabilityPolicy(Enum):
+    """Enum to mimic ROS2 `DurabilityPolicy`.
+
+    Reference:
+    https://docs.ros2.org/foxy/api/rclpy/api/qos.html#rclpy.qos.DurabilityPolicy
+    """
+
+    SYSTEM_DEFAULT = 0
+    TRANSIENT_LOCAL = 1
+    VOLATILE = 2
+
+
+######################
+# QoSProfile class
+######################
+
+class QoSProfile(object):
+    """QoSProfile class to mimic ROS2 `QoSProfile`.
+
+    Reference:
+    https://docs.ros2.org/foxy/api/rclpy/api/qos.html
+    https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html
+    """
+
+    def __init__(self, depth, durability = DurabilityPolicy.SYSTEM_DEFAULT, **kwargs):
+        """Initialize the class.
+
+        Arguments:
+        depth -- number of messages to hold (queue size), int
+        durability -- how to treat messages for new subscribers, DurabilityPolicy
+        **kwargs -- other, currently unsupported arguments
+
+        Reference:
+        https://docs.ros2.org/foxy/api/rclpy/api/qos.html#rclpy.qos.QoSProfile
+        """
+        self.depth = depth
+        self.durability = durability


### PR DESCRIPTION
This was a necessary step for #7. The compatible implementation is quite limited, but now we can do latched publishers.