### PR TITLE
Overload operators

### DIFF
--- a/autopsy/reconfigure.py
+++ b/autopsy/reconfigure.py
@@ -106,6 +106,10 @@ inside the parameter and announced to the reconfigure GUI.
 import rospy
 
 
+# Overloading the operators
+import operator
+
+
 # Enumerated parameters support
 from enum import Enum, EnumMeta
 
@@ -321,29 +325,26 @@ class Parameter(object):
     # Note: It would be nice to get around this by returning a value
     # when calling P.parameter instead of the object. But currently, I have no
     # idea how to do this.
-    def __add__(self, other):
-        return self.value + (other.value if isinstance(other, Parameter) else other)
+    def __operator__(first, second, operator):
+        return operator(
+            first.value if isinstance(first, Parameter) else first,
+            second.value if isinstance(second, Parameter) else second
+        )
 
+
+    __add__ = lambda first, second: Parameter.__operator__(first, second, operator.add)
     # These are added so you can do also
     # e.g. 5 + P.value
     __radd__ = __add__
 
-    def __sub__(self, other):
-        return self.value - (other.value if isinstance(other, Parameter) else other)
+    __sub__ = lambda first, second: Parameter.__operator__(first, second, operator.sub)
+    __rsub__ = lambda first, second: Parameter.__operator__(second, first, operator.sub)
 
-    def __rsub__(self, other):
-        return (other.value if isinstance(other, Parameter) else other) - self.value
+    __mul__ = lambda first, second: Parameter.__operator__(first, second, operator.mul)
+    __rmul__ = lambda first, second: Parameter.__operator__(second, first, operator.mul)
 
-    def __mul__(self, other):
-        return self.value * (other.value if isinstance(other, Parameter) else other)
-
-    __rmul__ = __mul__
-
-    def __div__(self, other):
-        return self.value / (other.value if isinstance(other, Parameter) else other)
-
-    def __rdiv__(self, other):
-        return (other.value if isinstance(other, Parameter) else other) / self.value
+    __div__ = lambda first, second: Parameter.__operator__(first, second, operator.div)
+    __rdiv__ = lambda first, second: Parameter.__operator__(second, first, operator.div)
 
 
 class ConstrainedP(Parameter):

--- a/autopsy/reconfigure.py
+++ b/autopsy/reconfigure.py
@@ -334,6 +334,8 @@ class Parameter(object):
 
     __operators = ["abs", "add", "and", "div", "floordiv", "lshift", "mod", "mul", "or", "pow", "rshift", "sub", "truediv", "xor"]
 
+    __comparators = ["lt", "le", "eq", "ne", "ge", "gt"]
+
     for op in __operators:
         vars()["__%s__" % op] = lambda first, second, op = "__%s__" % op: Parameter.__operator__(first, second, operator.__dict__[op])
         vars()["__r%s__" % op] = lambda first, second, op = "__%s__" % op: Parameter.__operator__(second, first, operator.__dict__[op])
@@ -347,6 +349,9 @@ class Parameter(object):
         #
         #vars()[_operator] = _
         #vars()["__r%s__" % op] = __
+
+    for op in __comparators:
+        vars()["__%s__" % op] = lambda first, second, op = "__%s__" % op: Parameter.__operator__(first, second, operator.__dict__[op])
 
 
 class ConstrainedP(Parameter):

--- a/autopsy/reconfigure.py
+++ b/autopsy/reconfigure.py
@@ -344,6 +344,8 @@ class Parameter(object):
 
     __uoperators = ["abs", "index", "invert", "neg", "pos"]
 
+    __functions = ["int", "float", "complex", "round", "trunc", "floor", "ceil"]
+
     for op in __operators:
         vars()["__%s__" % op] = lambda first, second, op = "__%s__" % op: Parameter.__operator__(first, second, operator.__dict__[op])
         vars()["__r%s__" % op] = lambda first, second, op = "__%s__" % op: Parameter.__operator__(second, first, operator.__dict__[op])
@@ -363,6 +365,9 @@ class Parameter(object):
 
     for op in __uoperators:
         vars()["__%s__" % op] = lambda first, second = None, op = "__%s__" % op: Parameter.__operator__(first, second, operator.__dict__[op])
+
+    for op in __functions:
+        vars()["__%s__" % op] = lambda first, op = "__%s__" % op: getattr(first.value, op)()
 
 
 class ConstrainedP(Parameter):

--- a/autopsy/reconfigure.py
+++ b/autopsy/reconfigure.py
@@ -325,16 +325,24 @@ class Parameter(object):
     # Note: It would be nice to get around this by returning a value
     # when calling P.parameter instead of the object. But currently, I have no
     # idea how to do this.
+    # Other note: Currently, 'is', 'not' and 'bool()' are not supported.
     @staticmethod
-    def __operator__(first, second, operator):
-        return operator(
-            first.value if isinstance(first, Parameter) else first,
-            second.value if isinstance(second, Parameter) else second
-        )
+    def __operator__(first, second = None, operator = None):
+        if second is None:
+            return operator(
+                first.value if isinstance(first, Parameter) else first
+            )
+        else:
+            return operator(
+                first.value if isinstance(first, Parameter) else first,
+                second.value if isinstance(second, Parameter) else second
+            )
 
     __operators = ["abs", "add", "and", "div", "floordiv", "lshift", "mod", "mul", "or", "pow", "rshift", "sub", "truediv", "xor"]
 
     __comparators = ["lt", "le", "eq", "ne", "ge", "gt"]
+
+    __uoperators = ["abs", "index", "invert", "neg", "pos"]
 
     for op in __operators:
         vars()["__%s__" % op] = lambda first, second, op = "__%s__" % op: Parameter.__operator__(first, second, operator.__dict__[op])
@@ -352,6 +360,9 @@ class Parameter(object):
 
     for op in __comparators:
         vars()["__%s__" % op] = lambda first, second, op = "__%s__" % op: Parameter.__operator__(first, second, operator.__dict__[op])
+
+    for op in __uoperators:
+        vars()["__%s__" % op] = lambda first, second = None, op = "__%s__" % op: Parameter.__operator__(first, second, operator.__dict__[op])
 
 
 class ConstrainedP(Parameter):

--- a/autopsy/reconfigure.py
+++ b/autopsy/reconfigure.py
@@ -317,6 +317,35 @@ class Parameter(object):
         return "%s: %s" % (self.name, self.value)
 
 
+    # Overloading operators
+    # Note: It would be nice to get around this by returning a value
+    # when calling P.parameter instead of the object. But currently, I have no
+    # idea how to do this.
+    def __add__(self, other):
+        return self.value + (other.value if isinstance(other, Parameter) else other)
+
+    # These are added so you can do also
+    # e.g. 5 + P.value
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        return self.value - (other.value if isinstance(other, Parameter) else other)
+
+    def __rsub__(self, other):
+        return (other.value if isinstance(other, Parameter) else other) - self.value
+
+    def __mul__(self, other):
+        return self.value * (other.value if isinstance(other, Parameter) else other)
+
+    __rmul__ = __mul__
+
+    def __div__(self, other):
+        return self.value / (other.value if isinstance(other, Parameter) else other)
+
+    def __rdiv__(self, other):
+        return (other.value if isinstance(other, Parameter) else other) / self.value
+
+
 class ConstrainedP(Parameter):
     """Parameter that is constrained by min and max values."""
 

--- a/autopsy/reconfigure.py
+++ b/autopsy/reconfigure.py
@@ -325,26 +325,28 @@ class Parameter(object):
     # Note: It would be nice to get around this by returning a value
     # when calling P.parameter instead of the object. But currently, I have no
     # idea how to do this.
+    @staticmethod
     def __operator__(first, second, operator):
         return operator(
             first.value if isinstance(first, Parameter) else first,
             second.value if isinstance(second, Parameter) else second
         )
 
+    __operators = ["abs", "add", "and", "div", "floordiv", "lshift", "mod", "mul", "or", "pow", "rshift", "sub", "truediv", "xor"]
 
-    __add__ = lambda first, second: Parameter.__operator__(first, second, operator.add)
-    # These are added so you can do also
-    # e.g. 5 + P.value
-    __radd__ = __add__
+    for op in __operators:
+        vars()["__%s__" % op] = lambda first, second, op = "__%s__" % op: Parameter.__operator__(first, second, operator.__dict__[op])
+        vars()["__r%s__" % op] = lambda first, second, op = "__%s__" % op: Parameter.__operator__(second, first, operator.__dict__[op])
 
-    __sub__ = lambda first, second: Parameter.__operator__(first, second, operator.sub)
-    __rsub__ = lambda first, second: Parameter.__operator__(second, first, operator.sub)
-
-    __mul__ = lambda first, second: Parameter.__operator__(first, second, operator.mul)
-    __rmul__ = lambda first, second: Parameter.__operator__(second, first, operator.mul)
-
-    __div__ = lambda first, second: Parameter.__operator__(first, second, operator.div)
-    __rdiv__ = lambda first, second: Parameter.__operator__(second, first, operator.div)
+        # Could be also done using:
+        #def _(first, second, op = _operator):
+        #    return Parameter.__operator__(first, second, operator.__dict__[op])
+        #
+        #def __(first, second, op = _operator):
+        #    return Parameter.__operator__(second, first, operator.__dict__[op])
+        #
+        #vars()[_operator] = _
+        #vars()["__r%s__" % op] = __
 
 
 class ConstrainedP(Parameter):


### PR DESCRIPTION
Overloading of (almost) all operators. This means that `.value` won't be used in 99% of cases.

Nevertheless, these are not supported:
 - `is`
 - `not`
 - `bool()`

... And maybe some others.

It is designed in such a way that the operator logic is on the original types.