### PR TITLE
Complete ROS wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   - Support for latched publishers.
   - ROS services.
   - Function `get_name()` for ROS1 version of the module.
+  - `ROS_VERSION` variable.
+  - Functions not implemented are called in the current ROS version with warning.
 - Documentation for the package.
 
 ### Changed

--- a/autopsy/node.py
+++ b/autopsy/node.py
@@ -64,12 +64,17 @@ try:
 
     from .ros1_node import Node as NodeI
     from .ros1_qos import *
+
+    ROS_VERSION = 1
 except:
     try:
         from rclpy.node import Node as NodeI
         from rclpy.qos import *
+
+        ROS_VERSION = 2
     except:
         print ("No ROS package detected.")
+        ROS_VERSION = 0
 
 
 ######################

--- a/autopsy/node.py
+++ b/autopsy/node.py
@@ -71,6 +71,8 @@ except:
         from rclpy.node import Node as NodeI
         from rclpy.qos import *
 
+        from .ros1_node import Node as NodeR1
+
         ROS_VERSION = 2
     except:
         print ("No ROS package detected.")
@@ -159,3 +161,34 @@ class Node(NodeI):
         http://docs.ros.org/en/kinetic/api/rospy/html/rospy.impl.tcpros_service.Service-class.html
         """
         return super(Node, self).create_service(srv_type = service_class, srv_name = name, callback = handler)
+
+
+    def __getattr__(self, name):
+        """Try to find undefined function in the current ROS environment.
+
+        Arguments:
+        name -- name of the attribute / method
+        """
+
+        if ROS_VERSION == 1:
+            if hasattr(rospy, name):
+                print ("[WARNING] Unsupported attribute 'rospy.%s'." % name)
+
+            return getattr(rospy, name)
+        else:
+            # Raise AttributeError
+            return super(Node, self).__getattribute__(name)
+
+
+    def __getattribute__(self, name):
+        """Get attribute and warn if not supported in uninode.
+
+        Arguments:
+        name -- name of the attribute / method
+        """
+
+        if ROS_VERSION == 2:
+            if not hasattr(NodeR1, name):
+                print ("[WARNING] Unsupported attribute 'self.%s'." % name)
+
+        return super(Node, self).__getattribute__(name)

--- a/autopsy/ros1_node.py
+++ b/autopsy/ros1_node.py
@@ -6,7 +6,10 @@
 # Imports & Globals
 ######################
 
-import rospy
+try:
+    import rospy
+except:
+    pass
 
 from .ros1_qos import DurabilityPolicy
 


### PR DESCRIPTION
This adds `ROS_VERSION` variable to be able to do some parts of code in selected version of ROS only. Also, additional functions that are not present in the implementation are called in the current ROS version with a warning.