### PR TITLE
Support reconfigure on ROS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,24 @@ Note: Lines with '+' denote that the same function as for ROS2 can be used for u
     - Timer in ROS2 does not take any arguments (in contrast to the 'rospy.TimerEvent
       in ROS1). Therefore, the function has to be created as:
       `def callback(self, *args, **kwargs)`
+- Common
+    - Services are handled slightly differently in both ROS versions. At first, service
+      message is compiled into two in ROS1. In ROS2 there is only one message type.
+      In addition, service callback has only one argument in ROS1, whereas there are
+      two arguments in ROS2 (second is the response).
+      To make it compatible with both versions stick to this:
+      ```python
+      if autopsy.node.ROS_VERSION == 1:
+          from package.srv import ResponseMessage
+
+      def callback(self, msg, response = None):
+          ...
+          if response is None:
+              return ResponseMessage(...)
+          else:
+              response.data = ...
+              return response
+      ```
 
 
 ### Full example

--- a/autopsy/node.py
+++ b/autopsy/node.py
@@ -35,6 +35,24 @@ Differences:
     - Timer in ROS2 does not take any arguments (in contrast to the 'rospy.TimerEvent
       in ROS1). Therefore, the function has to be created as:
       `def callback(self, *args, **kwargs)`
+- Common
+    - Services are handled slightly differently in both ROS versions. At first, service
+      message is compiled into two in ROS1. In ROS2 there is only one message type.
+      In addition, service callback has only one argument in ROS1, whereas there are
+      two arguments in ROS2 (second is the response).
+      To make it compatible with both versions stick to this:
+      ```python
+      if autopsy.node.ROS_VERSION == 1:
+          from package.srv import ResponseMessage
+
+      def callback(self, msg, response = None):
+          ...
+          if response is None:
+              return ResponseMessage(...)
+          else:
+              response.data = ...
+              return response
+      ```
 
 
 Example:

--- a/autopsy/reconfigure.py
+++ b/autopsy/reconfigure.py
@@ -116,7 +116,11 @@ from enum import Enum, EnumMeta
 
 # Message types
 from dynamic_reconfigure.msg import ConfigDescription, Config, Group, ParamDescription, BoolParameter, IntParameter, StrParameter, DoubleParameter, GroupState
-from dynamic_reconfigure.srv import Reconfigure, ReconfigureResponse
+from dynamic_reconfigure.srv import Reconfigure
+
+if autopsy.node.ROS_VERSION == 1:
+    # ROS1 compiles the messages into two, in contrast to ROS2.
+    from dynamic_reconfigure.srv import ReconfigureResponse
 
 
 # https://stackoverflow.com/questions/2440692/formatting-floats-without-trailing-zeros
@@ -699,7 +703,7 @@ class ParameterReconfigure(object):
         self._update = _config
 
 
-    def _reconfigureCallback(self, data):
+    def _reconfigureCallback(self, data, response = None):
         """Service callback for dynamic reconfiguration.
 
         Arguments:
@@ -726,9 +730,13 @@ class ParameterReconfigure(object):
             self._updatePub()
 
 
-        return ReconfigureResponse(
-            self._get_config(condition = lambda x: x in _updated)
-        )
+        if response is None:
+            return ReconfigureResponse(
+                self._get_config(condition = lambda x: x in _updated)
+            )
+        else:
+            response.config = self._get_config(condition = lambda x: x in _updated)
+            return response
 
 
     def __str__(self):


### PR DESCRIPTION
This should make reconfigure node runnable under ROS2. However, it is still using the `dynamic_reconfigure`, therefore it is probably not compatible with `ros2 param`.